### PR TITLE
Make inline style tags configurable

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,16 +1,10 @@
 module.exports = function(id, options) {
   // Build the string, using config data as we go
-  // unique ID based on video id
-  let out =
-    '<div id="vimeo-' + id + '" ';
-  // global class name for all embeds of this type, use this for styling
-  out += 'class="' + options.embedClass + '" ';
-  // intrinsic aspect ratio; currently hard-coded to 16:9
-  // TODO: make configurable somehow
-  out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
-  out +=
-    '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
-  out += 'width="100%" height="100%" frameborder="0" ';
+  // unique ID based on video id and global class name for all embeds
+  let out = `<div id="vimeo-${id}" class="${options.embedClass}" `;
+  out += `style="${options.wrapperStyle}">`;
+  out += `<iframe style="${options.iframeStyle}" `;
+  out += 'frameborder="0" ';
   out += 'src="https://player.vimeo.com/video/';
   out += id;
   out += options.dnt ? '?dnt=1' : '?dnt=0';

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,11 +1,12 @@
 module.exports = function(id, options) {
   // Build the string, using config data as we go
   // unique ID based on video id and global class name for all embeds
-  let out = `<div id="vimeo-${id}" class="${options.embedClass}" `;
-  out += `style="${options.wrapperStyle}">`;
-  out += `<iframe style="${options.iframeStyle}" `;
-  out += 'frameborder="0" ';
-  out += 'src="https://player.vimeo.com/video/';
+  let out = `<div id="vimeo-${id}" class="${options.embedClass}"`;
+  out += options.wrapperStyle ? ` style="${options.wrapperStyle}">` : ">";
+  out += `<iframe`
+  out += options.iframeStyle ? ` style="${options.iframeStyle}"` : "";
+  out += ' frameborder="0"';
+  out += ' src="https://player.vimeo.com/video/';
   out += id;
   out += options.dnt ? '?dnt=1' : '?dnt=0';
   out += '"';

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,5 +1,13 @@
 module.exports = {
   allowFullscreen: true,
   dnt: true,
-  embedClass: 'eleventy-plugin-vimeo-embed'
+  embedClass: 'eleventy-plugin-vimeo-embed',
+  
+  /**
+   * By default, uses the Intrinsic Aspect Ratio technique
+   * https://codepen.io/gfscott/pen/qpKqZR?editors=1100
+   * Pass an options object with alternate inline styles to override
+   */
+  iframeStyle: 'position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;',
+  wrapperStyle: 'position:relative;width:100%;padding-top:56.25%;',
 };

--- a/test.js
+++ b/test.js
@@ -200,13 +200,13 @@ validStrings.forEach(function(obj){
   test(`Expected HTML returned; case: custom style strings: ${obj.type} ideal case`, t => {
     let idealCase = `<p>${obj.str}</p>`;
     t.is(buildEmbed(extractId(idealCase), optionsCustomStyleStrings),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: custom style strings: ${obj.type} with links`, t => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
     t.is(buildEmbed(extractId(withLinks), optionsCustomStyleStrings),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: custom style strings: ${obj.type} with whitespace`, t => {
@@ -214,7 +214,7 @@ validStrings.forEach(function(obj){
       ${obj.str}
     </p>`;
     t.is(buildEmbed(extractId(withWhitespace), optionsCustomStyleStrings),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: custom style strings: ${obj.type} with links and whitespace`, t => {
@@ -224,7 +224,7 @@ validStrings.forEach(function(obj){
       </a>
     </p>`;
     t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsCustomStyleStrings),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
 });

--- a/test.js
+++ b/test.js
@@ -83,13 +83,13 @@ validStrings.forEach(function(obj){
   test(`Expected HTML returned: ${obj.type} ideal case`, t => {
     let idealCase = `<p>${obj.str}</p>`;
     t.is(buildEmbed(extractId(idealCase), pluginDefaults),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned: ${obj.type} with links`, t => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
     t.is(buildEmbed(extractId(withLinks), pluginDefaults),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned: ${obj.type} with whitespace`, t => {
@@ -97,7 +97,7 @@ validStrings.forEach(function(obj){
       ${obj.str}
     </p>`;
     t.is(buildEmbed(extractId(withWhitespace), pluginDefaults),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned: ${obj.type} with links and whitespace`, t => {
@@ -107,7 +107,7 @@ validStrings.forEach(function(obj){
       </a>
     </p>`;
     t.is(buildEmbed(extractId(withLinksAndWhitespace), pluginDefaults),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
 });
@@ -121,13 +121,13 @@ validStrings.forEach(function(obj){
   test(`Expected HTML returned; case: DNT false: ${obj.type} ideal case`, t => {
     let idealCase = `<p>${obj.str}</p>`;
     t.is(buildEmbed(extractId(idealCase), optionsDntFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: DNT false: ${obj.type} with links`, t => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
     t.is(buildEmbed(extractId(withLinks), optionsDntFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: DNT false: ${obj.type} with whitespace`, t => {
@@ -135,7 +135,7 @@ validStrings.forEach(function(obj){
       ${obj.str}
     </p>`;
     t.is(buildEmbed(extractId(withWhitespace), optionsDntFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: DNT false: ${obj.type} with links and whitespace`, t => {
@@ -145,7 +145,7 @@ validStrings.forEach(function(obj){
       </a>
     </p>`;
     t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsDntFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
     );
   });
 });
@@ -159,13 +159,13 @@ validStrings.forEach(function(obj){
   test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} ideal case`, t => {
     let idealCase = `<p>${obj.str}</p>`;
     t.is(buildEmbed(extractId(idealCase), optionsFullscreenFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with links`, t => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
     t.is(buildEmbed(extractId(withLinks), optionsFullscreenFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with whitespace`, t => {
@@ -173,7 +173,7 @@ validStrings.forEach(function(obj){
       ${obj.str}
     </p>`;
     t.is(buildEmbed(extractId(withWhitespace), optionsFullscreenFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
     );
   });
   test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with links and whitespace`, t => {
@@ -183,7 +183,48 @@ validStrings.forEach(function(obj){
       </a>
     </p>`;
     t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsFullscreenFalse),
-      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+    );
+  });
+});
+
+/**
+ * Test that embed builder returns expected HTML with non-default options
+ */
+const customStyles = {
+  wrapperStyle: '',
+  iframeStyle: '',
+}
+const optionsCustomStyleStrings = Object.assign({}, pluginDefaults, customStyles);
+validStrings.forEach(function(obj){
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style=""><iframe style="" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
     );
   });
 });


### PR DESCRIPTION
Resolves #14 

This PR adds the option to override the inline style tags for both the wrapper div and the iframe elements. This will enable users to specify their own styles in their own stylesheets, using the already-configurable class on the wrapper div.

Example usage:
```js
eleventyConfig.addPlugin(embedVimeo, {
  embedClass: 'custom-class-name',
  iframeStyle: '',
  wrapperStyle: '',
});
```

In the case of Vimeo, the result is that the default embed is quite small, but to me the point of making this change is to make the elements targetable with existing stylesheets through the wrapper class name alone.

One side effect of this change is that I've opted to remove the 100% `width` and `height` attributes on the `iframe` element. They're redundant with the default inline style and I'm not sure they're entirely necessary. I'm going to do a little more research on this aspect-ratio hack before merging, but I wanted to file this now as a proof-of-concept and invite comment.

@alienlebarge interested if this meets what you had in mind!